### PR TITLE
Real life transforms

### DIFF
--- a/AirSim/AirLib/include/common/AirSimSettings.hpp
+++ b/AirSim/AirLib/include/common/AirSimSettings.hpp
@@ -216,7 +216,6 @@ public: //types
         Rotation rotation = Rotation::nanRotation();
 
         bool draw_debug_points = false;
-        std::string data_frame = AirSimSettings::kVehicleInertialFrame;
     };
 
     struct VehicleSetting {
@@ -1168,7 +1167,6 @@ private:
         lidar_setting.points_per_second = settings_json.getInt("PointsPerSecond", lidar_setting.points_per_second);
         lidar_setting.horizontal_rotation_frequency = settings_json.getInt("RotationsPerSecond", lidar_setting.horizontal_rotation_frequency);
         lidar_setting.draw_debug_points = settings_json.getBool("DrawDebugPoints", lidar_setting.draw_debug_points);
-        lidar_setting.data_frame = settings_json.getString("DataFrame", lidar_setting.data_frame);
 
         lidar_setting.vertical_FOV_upper = settings_json.getFloat("VerticalFOVUpper", lidar_setting.vertical_FOV_upper);
         lidar_setting.vertical_FOV_lower = settings_json.getFloat("VerticalFOVLower", lidar_setting.vertical_FOV_lower);

--- a/AirSim/AirLib/include/sensors/lidar/LidarSimpleParams.hpp
+++ b/AirSim/AirLib/include/sensors/lidar/LidarSimpleParams.hpp
@@ -32,7 +32,6 @@ struct LidarSimpleParams {
         };                       
 
     bool draw_debug_points = false;
-    std::string data_frame = AirSimSettings::kVehicleInertialFrame;
 
     real_T update_frequency = 10;             // Hz
     real_T startup_delay = 0;                 // sec
@@ -89,7 +88,6 @@ struct LidarSimpleParams {
             Utils::degreesToRadians(yaw));    //yaw   - rotation around Z axis
            
         draw_debug_points = settings.draw_debug_points;
-        data_frame = settings.data_frame;
     }
 };
 

--- a/UE4Project/Plugins/AirSim/Settings/settings.json
+++ b/UE4Project/Plugins/AirSim/Settings/settings.json
@@ -28,8 +28,8 @@
             "Enabled": true,
             "NumberOfChannels": 16,
             "PointsPerSecond": 10000,
-            "X": 10,
-            "Y": 25,
+            "X": 0,
+            "Y": 0,
             "Z": -1,
             "DrawDebugPoints": false
           }

--- a/UE4Project/Plugins/AirSim/Settings/settings.json
+++ b/UE4Project/Plugins/AirSim/Settings/settings.json
@@ -28,8 +28,8 @@
             "Enabled": true,
             "NumberOfChannels": 16,
             "PointsPerSecond": 10000,
-            "X": 0,
-            "Y": 0,
+            "X": 10,
+            "Y": 25,
             "Z": -1,
             "DrawDebugPoints": false
           }

--- a/UE4Project/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/UE4Project/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -655,18 +655,9 @@ void ASimModeBase::drawLidarDebugPoints()
                     for (int j = 0; j < lidar_data.point_cloud.size(); j = j + 3) {
                         msr::airlib::Vector3r point(lidar_data.point_cloud[j], lidar_data.point_cloud[j + 1], lidar_data.point_cloud[j + 2]);
 
-                        FVector uu_point;
+                        msr::airlib::Vector3r point_w = msr::airlib::VectorMath::transformToWorldFrame(point, lidar_data.pose, true);
+                        FVector uu_point = pawn_sim_api->getNedTransform().fromLocalNed(point_w);
 
-                        if (lidar->getParams().data_frame == AirSimSettings::kVehicleInertialFrame) {
-                            uu_point = pawn_sim_api->getNedTransform().fromLocalNed(point);
-                        }
-                        else if (lidar->getParams().data_frame == AirSimSettings::kSensorLocalFrame) {
-
-                            msr::airlib::Vector3r point_w = msr::airlib::VectorMath::transformToWorldFrame(point, lidar_data.pose, true);
-                            uu_point = pawn_sim_api->getNedTransform().fromLocalNed(point_w);
-                        }
-                        else
-                            throw std::runtime_error("Unknown requested data frame");
 
                         DrawDebugPoint(
                             this->GetWorld(),

--- a/UE4Project/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/UE4Project/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -175,7 +175,7 @@ bool UnrealLidarSensor::shootLaser(const msr::airlib::Pose& lidar_pose, const ms
             Vector3r point_v_i = ned_transform_->toLocalNed(hit_result.ImpactPoint);
 
             // tranform to lidar frame
-            point = VectorMath::transformToBodyFrame(point_v_i, lidar_pose + vehicle_pose, true);
+            point = VectorMath::transformToBodyFrame(point_v_i, lidar_pose, true);
 
             // The above should be same as first transforming to vehicle-body frame and then to lidar frame
             //    Vector3r point_v_b = VectorMath::transformToBodyFrame(point_v_i, vehicle_pose, true);

--- a/UE4Project/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/UE4Project/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -164,33 +164,24 @@ bool UnrealLidarSensor::shootLaser(const msr::airlib::Pose& lidar_pose, const ms
             );
         }
 
-        // decide the frame for the point-cloud
-        if (params.data_frame == AirSimSettings::kVehicleInertialFrame) {
-            // current detault behavior; though it is probably not very useful.
-            // not changing the default for now to maintain backwards-compat.
-            point = ned_transform_->toLocalNed(hit_result.ImpactPoint);
-        }
-        else if (params.data_frame == AirSimSettings::kSensorLocalFrame) {
-            // point in vehicle intertial frame
-            Vector3r point_v_i = ned_transform_->toLocalNed(hit_result.ImpactPoint);
 
-            // tranform to lidar frame
-            point = VectorMath::transformToBodyFrame(point_v_i, lidar_pose, true);
+        // point in vehicle intertial frame
+        Vector3r point_v_i = ned_transform_->toLocalNed(hit_result.ImpactPoint);
 
-            // The above should be same as first transforming to vehicle-body frame and then to lidar frame
-            //    Vector3r point_v_b = VectorMath::transformToBodyFrame(point_v_i, vehicle_pose, true);
-            //    point = VectorMath::transformToBodyFrame(point_v_b, lidar_pose, true);
+        // tranform to lidar frame
+        point = VectorMath::transformToBodyFrame(point_v_i, lidar_pose + vehicle_pose, true);
 
-            // On the client side, if it is needed to transform this data back to the world frame,
-            // then do the equivalent of following,
-            //     Vector3r point_w = VectorMath::transformToWorldFrame(point, lidar_pose + vehicle_pose, true);
-            // See SimModeBase::drawLidarDebugPoints()
+        // The above should be same as first transforming to vehicle-body frame and then to lidar frame
+        //    Vector3r point_v_b = VectorMath::transformToBodyFrame(point_v_i, vehicle_pose, true);
+        //    point = VectorMath::transformToBodyFrame(point_v_b, lidar_pose, true);
 
-            // TODO: Optimization -- instead of doing this for every point, it should be possible to do this
-            // for the point-cloud together? Need to look into matrix operations to do this together for all points.
-        }
-        else 
-            throw std::runtime_error("Unknown requested data frame");
+        // On the client side, if it is needed to transform this data back to the world frame,
+        // then do the equivalent of following,
+        //     Vector3r point_w = VectorMath::transformToWorldFrame(point, lidar_pose + vehicle_pose, true);
+        // See SimModeBase::drawLidarDebugPoints()
+
+        // TODO: Optimization -- instead of doing this for every point, it should be possible to do this
+        // for the point-cloud together? Need to look into matrix operations to do this together for all points.
 
         return true;
     }

--- a/docs/ros-bridge.md
+++ b/docs/ros-bridge.md
@@ -49,7 +49,8 @@ The contents of this message fill the essential parts of the `msr::airlib::CarAp
 ## Coordinate frames and transforms
 
 The primary frame is the `fsds/FSCar` frame.
-This frame centers the core of the car.
+This frame centers the center of the car.
+The center of the car is the Unreal Engine car pawn position, which in turn is also the center of gravity.
 It is using the NED coordinate system.
 The `fsds/FSCar/enu` frame is the same point, translated to the ENU system.
 Read more about the differences between ENU and NED [here](https://en.wikipedia.org/wiki/Local_tangent_plane_coordinates).

--- a/docs/ros-bridge.md
+++ b/docs/ros-bridge.md
@@ -46,6 +46,21 @@ The contents of this message fill the essential parts of the `msr::airlib::CarAp
 - `/fsds_ros_bridge/reset` [fsds_ros_bridge/Reset](../ros/src/fsds_ros_bridge/srv/Empty.html)
  Resets car to start location.
 
+## Coordinate frames and transforms
+
+The primary frame is the `fsds/FSCar` frame.
+This frame centers the core of the car.
+It is using the NED coordinate system.
+The `fsds/FSCar/enu` frame is the same point, translated to the ENU system.
+Read more about the differences between ENU and NED [here](https://en.wikipedia.org/wiki/Local_tangent_plane_coordinates).
+
+The ros bridge regularly publishes static transforms between the `fsds/FSCar` frame and each of the cameras and lidars.
+Naming of these frames is `fsds/SENSORNAME`.
+For example, a lidar named `Example` will publish it's points in the `fsds/Example` frame.
+
+Only static transforms within the vehicle are published.
+Transforms to the ground truth are disabled because this would take away the challenge of the competition.
+
 ## Parameters
 - `/fsds_ros_bridge/update_airsim_control_every_n_sec` [double]   
   Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`   

--- a/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
+++ b/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
@@ -160,7 +160,7 @@ private:
     fsds_ros_bridge::GPSYaw get_gps_msg_from_airsim_geo_point(const msr::airlib::GeoPoint& geo_point) const;
     sensor_msgs::NavSatFix get_gps_sensor_msg_from_airsim_geo_point(const msr::airlib::GeoPoint& geo_point) const;
     sensor_msgs::Imu get_imu_msg_from_airsim(const msr::airlib::ImuBase::Output& imu_data);
-    sensor_msgs::PointCloud2 get_lidar_msg_from_airsim(const msr::airlib::LidarData& lidar_data) const;
+    sensor_msgs::PointCloud2 get_lidar_msg_from_airsim(const std::string &lidar_name, const msr::airlib::LidarData& lidar_data) const;
 
     // not used anymore, but can be useful in future with an unreal camera calibration environment
     void read_params_from_yaml_and_fill_cam_info_msg(const std::string& file_name, sensor_msgs::CameraInfo& cam_info) const;

--- a/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
+++ b/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
@@ -133,10 +133,6 @@ private:
     /// ROS service callbacks
     bool reset_srv_cb(fsds_ros_bridge::Reset::Request& request, fsds_ros_bridge::Reset::Response& response);
 
-    /// ROS tf broadcasters
-    void publish_camera_tf(const ImageResponse& img_response, const ros::Time& ros_time, const std::string& frame_id, const std::string& child_frame_id);
-    void publish_odom_tf(const nav_msgs::Odometry& odom_ned_msg);
-
     /// camera helper methods
     sensor_msgs::CameraInfo generate_cam_info(const std::string& camera_name, const CameraSetting& camera_setting, const CaptureSetting& capture_setting) const;
     cv::Mat manual_decode_depth(const ImageResponse& img_response) const;
@@ -225,7 +221,6 @@ private:
     // std::recursive_mutex lidar_mutex_;
 
     /// ROS tf
-    std::string world_frame_id_;
     tf2_ros::TransformBroadcaster tf_broadcaster_;
     tf2_ros::StaticTransformBroadcaster static_tf_pub_;
     tf2_ros::Buffer tf_buffer_;

--- a/ros/src/fsds_ros_bridge/launch/static_transforms.launch
+++ b/ros/src/fsds_ros_bridge/launch/static_transforms.launch
@@ -1,3 +1,3 @@
 <launch>
-	<node pkg="tf" type="static_transform_publisher" name="ned_to_enu_pub" args="0 0 0 1.57 0 3.14 world_ned world_enu 100"/>
+	<node pkg="tf" type="static_transform_publisher" name="ned_to_enu_pub" args="0 0 0 1.57 0 3.14 FSCar FSCar_enu 100"/>
 </launch>

--- a/ros/src/fsds_ros_bridge/launch/static_transforms.launch
+++ b/ros/src/fsds_ros_bridge/launch/static_transforms.launch
@@ -1,3 +1,3 @@
 <launch>
-	<node pkg="tf" type="static_transform_publisher" name="ned_to_enu_pub" args="0 0 0 1.57 0 3.14 FSCar FSCar_enu 100"/>
+	<node pkg="tf" type="static_transform_publisher" name="ned_to_enu_pub" args="0 0 0 1.57 0 3.14 fsds/FSCar fsds/FSCar/enu 100"/>
 </launch>

--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -127,7 +127,7 @@ void AirsimROSWrapper::create_ros_pubs_from_settings_json()
         vehicle_name_idx_map_[curr_vehicle_name] = idx; // allows fast lookup in command callbacks in case of a lot of cars
 
         FSCarROS fscar_ros;
-        fscar_ros.odom_frame_id = curr_vehicle_name + "/odom_local_ned";
+        fscar_ros.odom_frame_id = "fsds/" + curr_vehicle_name + "/odom_local_ned";
         fscar_ros.vehicle_name = curr_vehicle_name;
         fscar_ros.odom_local_ned_pub = nh_private_.advertise<nav_msgs::Odometry>(curr_vehicle_name + "/odom_local_ned", 10);
         fscar_ros.global_gps_pub = nh_private_.advertise<sensor_msgs::NavSatFix>(curr_vehicle_name + "/global_gps", 10);
@@ -355,7 +355,7 @@ nav_msgs::Odometry AirsimROSWrapper::get_odom_msg_from_airsim_state(const msr::a
 sensor_msgs::PointCloud2 AirsimROSWrapper::get_lidar_msg_from_airsim(const std::string &lidar_name, const msr::airlib::LidarData& lidar_data) const
 {
     sensor_msgs::PointCloud2 lidar_msg;
-    lidar_msg.header.frame_id = lidar_name;
+    lidar_msg.header.frame_id = "fsds/"+lidar_name;
 
     if (lidar_data.point_cloud.size() > 3)
     {
@@ -505,7 +505,7 @@ void AirsimROSWrapper::car_state_timer_cb(const ros::TimerEvent& event)
                 }
 
                 sensor_msgs::Imu imu_msg = get_imu_msg_from_airsim(imu_data);
-                imu_msg.header.frame_id = vehicle_imu_pair.first;
+                imu_msg.header.frame_id = "fsds/" + vehicle_imu_pair.first;
                 // imu_msg.header.stamp = ros::Time::now();
                 {
                     ros_bridge::ROSMsgCounter counter(&imu_pub_vec_statistics[ctr]);
@@ -606,8 +606,8 @@ void AirsimROSWrapper::append_static_lidar_tf(const std::string& vehicle_name, c
 {
 
     geometry_msgs::TransformStamped lidar_tf_msg;
-    lidar_tf_msg.header.frame_id = vehicle_name;
-    lidar_tf_msg.child_frame_id = lidar_name;
+    lidar_tf_msg.header.frame_id = "fsds/" + vehicle_name;
+    lidar_tf_msg.child_frame_id = "fsds/" + lidar_name;
     lidar_tf_msg.transform.translation.x = lidar_setting.position.x();
     lidar_tf_msg.transform.translation.y = lidar_setting.position.y();
     lidar_tf_msg.transform.translation.z = lidar_setting.position.z();
@@ -624,8 +624,8 @@ void AirsimROSWrapper::append_static_lidar_tf(const std::string& vehicle_name, c
 void AirsimROSWrapper::append_static_camera_tf(const std::string& vehicle_name, const std::string& camera_name, const CameraSetting& camera_setting)
 {
     geometry_msgs::TransformStamped static_cam_tf_body_msg;
-    static_cam_tf_body_msg.header.frame_id = vehicle_name;
-    static_cam_tf_body_msg.child_frame_id = camera_name;
+    static_cam_tf_body_msg.header.frame_id = "fsds/" + vehicle_name;
+    static_cam_tf_body_msg.child_frame_id = "fsds/" + camera_name;
     static_cam_tf_body_msg.transform.translation.x = camera_setting.position.x();
     static_cam_tf_body_msg.transform.translation.y = camera_setting.position.y();
     static_cam_tf_body_msg.transform.translation.z = camera_setting.position.z();
@@ -692,7 +692,7 @@ void AirsimROSWrapper::lidar_timer_cb(const ros::TimerEvent& event)
                     lck.unlock();
                 }
                 lidar_msg = get_lidar_msg_from_airsim(vehicle_lidar_pair.second, lidar_data);     // todo make const ptr msg to avoid copy
-                lidar_msg.header.frame_id = vehicle_lidar_pair.second; // sensor frame name. todo add to doc
+                lidar_msg.header.frame_id = "fsds/" + vehicle_lidar_pair.second; // sensor frame name. todo add to doc
                 lidar_msg.header.stamp = ros::Time::now();
 
                 {
@@ -760,7 +760,7 @@ sensor_msgs::CameraInfo AirsimROSWrapper::generate_cam_info(const std::string& c
                                                             const CaptureSetting& capture_setting) const
 {
     sensor_msgs::CameraInfo cam_info_msg;
-    cam_info_msg.header.frame_id = camera_name + "/" + image_type_int_to_string_map_.at(capture_setting.image_type) + "_optical";
+    cam_info_msg.header.frame_id = "fsds/" + camera_name;
     cam_info_msg.height = capture_setting.height;
     cam_info_msg.width = capture_setting.width;
     float f_x = (capture_setting.width / 2.0) / tan(math_common::deg2rad(capture_setting.fov_degrees / 2.0));
@@ -803,14 +803,14 @@ void AirsimROSWrapper::process_and_publish_img_response(const std::vector<ImageR
         {
             image_pub_vec_[img_response_idx_internal].publish(get_depth_img_msg_from_response(curr_img_response,
                                                                                               curr_ros_time,
-                                                                                              curr_img_response.camera_name + "_optical"));
+                                                                                              "fsds/" + curr_img_response.camera_name));
         }
         // Scene / Segmentation / SurfaceNormals / Infrared
         else
         {
             image_pub_vec_[img_response_idx_internal].publish(get_img_msg_from_response(curr_img_response,
                                                                                         curr_ros_time,
-                                                                                        curr_img_response.camera_name + "_optical"));
+                                                                                        "fsds/" + curr_img_response.camera_name));
         }
         img_response_idx_internal++;
     }


### PR DESCRIPTION
In this pr all transforms, data frames and coordinate systems are configured to work like a real car. Large changes are:
1. For lidar, hard-code the dataframe of the points to the sensor frame. All lidar points should always be relative to the actual sensor.
2. For camera's, only publish the static transform between sensor body and center of the car. All other transforms have been removed.
3. Do not publish transforms between the car's location and the world. Using this data the ground truth of the car could be found which would defeat part of the challenge.
4. Prefixed all frames with `fsds/` to prevent collisions with existing frames.
5. Hard-coded the primary vehicle frame to FSCar.