### PR TITLE
Refactor IMU, Odometry and transform publishers to better work with a single car.

### DIFF
--- a/docs/ros-bridge.md
+++ b/docs/ros-bridge.md
@@ -19,21 +19,18 @@ roslaunch fsds_ros_bridge fsds_ros_bridge.launch
 ```
 
 ## Publishers
-- `/fsds_ros_bridge/origin_geo_point` [fsds_ros_bridge/GPSYaw](../ros/src/fsds_ros_bridge/msg/GPSYaw.msg)   
-GPS coordinates corresponding to global NED frame. This is set in the airsim's [settings.json](https://microsoft.github.io/AirSim/docs/settings/) file under (located [here](../../../UE4Project/Plugins/AirSim/Settings/settings.json)) the `OriginGeopoint` key. 
-
 - `/fsds_ros_bridge/VEHICLE_NAME/global_gps` [sensor_msgs/NavSatFix](https://docs.ros.org/api/sensor_msgs/html/msg/NavSatFix.html)   
 This the current GPS coordinates of the drone in airsim. 
 
-- `/fsds_ros_bridge/VEHICLE_NAME/odom_local_ned` [nav_msgs/Odometry](https://docs.ros.org/api/nav_msgs/html/msg/Odometry.html)   
-Odometry in NED frame wrt starting point.  THIS WILL NOT BE STREAMED DURING COMPETITION.
+- `/fsds_ros_bridge/VEHICLE_NAME/odom` [nav_msgs/Odometry](https://docs.ros.org/api/nav_msgs/html/msg/Odometry.html)
+Ground truth car position and orientation in NED frame. THIS WILL NOT BE STREAMED DURING COMPETITION.
 
 - `/fsds_ros_bridge/VEHICLE_NAME/CAMERA_NAME/IMAGE_TYPE/camera_info` [sensor_msgs/CameraInfo](https://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html)
 
 - `/fsds_ros_bridge/VEHICLE_NAME/CAMERA_NAME/IMAGE_TYPE` [sensor_msgs/Image](https://docs.ros.org/api/sensor_msgs/html/msg/Image.html)   
   RGB or float image depending on image type requested in [settings.json](../UE4Project/Plugins/AirSim/Settings/settings.json).
 
-- `/fsds_ros_bridge/VEHICLE_NAME/imu/SENSORNAME` [sensor_msgs/Imu](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/Imu.html)   
+- `/fsds_ros_bridge/VEHICLE_NAME/imu` [sensor_msgs/Imu](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/Imu.html)   
   See [imu.md](imu.md)
 
 - `/tf` [tf2_msgs/TFMessage](https://docs.ros.org/api/tf2_msgs/html/msg/TFMessage.html)
@@ -66,19 +63,34 @@ Only static transforms within the vehicle are published.
 Transforms to the ground truth are disabled because this would take away the challenge of the competition.
 
 ## Parameters
-- `/fsds_ros_bridge/update_airsim_control_every_n_sec` [double]   
-  Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`   
-  Default: 0.01 seconds.    
-  Timer callback frequency for updating drone odom and state from airsim, and sending in control commands.    
-  The current RPClib interface to unreal engine maxes out at 50 Hz.   
-  Timer callbacks in ROS run at maximum rate possible, so it's best to not touch this parameter. 
+- `/fsds_ros_bridge/update_gps_every_n_sec` [double]
+  Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`
+  Default: 0.1 seconds (10hz).
+  Timer callback frequency for updating and publishing the gps sensordata.
+  This value must be equal or higher to the update frequency of the sensor configured in the settings.json
 
-- `/fsds_ros_bridge/update_airsim_img_response_every_n_sec` [double]   
-  Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`   
-  Default: 0.01 seconds.    
-  Timer callback frequency for receiving images from all cameras in airsim.    
-  The speed will depend on number of images requested and their resolution.   
-  Timer callbacks in ROS run at maximum rate possible, so it's best to not touch this parameter. 
+- `/fsds_ros_bridge/update_imu_every_n_sec` [double]
+  Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`
+  Default: 0.004 seconds (250hz).
+  Timer callback frequency for updating and publishing the imu messages.
+  This value must be equal or higher to the minimual sample rate of the sensor configured in the settings.json
+
+- `/fsds_ros_bridge/update_odom_every_n_sec` [double]
+  Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`
+  Default: 0.004 seconds (250hz).
+  Timer callback frequency for updating and publishing the odometry.
+
+- `/fsds_ros_bridge/publish_static_tf_every_n_sec` [double]
+  Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`
+  Default: 1 seconds (1 hz).
+  The frequency at which the static transforms are published.
+
+- `/fsds_ros_bridge/update_airsim_img_response_every_n_sec` [double]
+  Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`
+  Default: 0.01 seconds.
+  Timer callback frequency for receiving images from all cameras in airsim.
+  The speed will depend on number of images requested and their resolution.
+  Timer callbacks in ROS run at maximum rate possible, so it's best to not touch this parameter.
 
 ## Visualization
 This package contains some useful launch and config files which will help you in visualizing the data being streamed through the above topics.

--- a/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
+++ b/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
@@ -98,15 +98,15 @@ private:
     ros_bridge::Statistics setCarControlsStatistics;
     ros_bridge::Statistics getGpsDataStatistics;
     ros_bridge::Statistics getCarStateStatistics;
-    std::vector<ros_bridge::Statistics> getImuDataVecStatistics;
+    ros_bridge::Statistics getImuStatistics;
     std::vector<ros_bridge::Statistics> simGetImagesVecStatistics;
     std::vector<ros_bridge::Statistics> getLidarDataVecStatistics;
     ros_bridge::Statistics control_cmd_sub_statistics;
     ros_bridge::Statistics global_gps_pub_statistics;
-    ros_bridge::Statistics odom_local_ned_pub_statistics;
+    ros_bridge::Statistics odom_pub_statistics;
     std::vector<ros_bridge::Statistics> cam_pub_vec_statistics;
     std::vector<ros_bridge::Statistics> lidar_pub_vec_statistics;
-    std::vector<ros_bridge::Statistics> imu_pub_vec_statistics;
+    ros_bridge::Statistics imu_pub_statistics;
     
     // create std::vector<Statistics*> which I can use to iterate over all these options 
     // and apply common operations such as print, reset
@@ -120,7 +120,10 @@ private:
 
     /// ROS timer callbacks
     void img_response_timer_cb(const ros::TimerEvent& event); // update images from airsim_client_ every nth sec
-    void car_state_timer_cb(const ros::TimerEvent& event);    // update drone state from airsim_client_ every nth sec
+    void odom_cb(const ros::TimerEvent& event);    // update drone state from airsim_client_ every nth sec
+    void gps_timer_cb(const ros::TimerEvent& event);
+    void imu_timer_cb(const ros::TimerEvent& event);
+    void statictf_cb(const ros::TimerEvent& event);
     void car_control_cb(const fsds_ros_bridge::ControlCommand::ConstPtr& msg, const std::string& vehicle_name);
     void lidar_timer_cb(const ros::TimerEvent& event);
     void statistics_timer_cb(const ros::TimerEvent& event);
@@ -172,33 +175,21 @@ private:
     {
         std::string vehicle_name;
 
-        /// All things ROS
-        ros::Publisher odom_local_ned_pub;
+        ros::Publisher odom_pub;
         ros::Publisher global_gps_pub;
+        ros::Publisher imu_pub;
         ros::Subscriber control_cmd_sub;
-
-        /// State
-        msr::airlib::CarApiBase::CarState curr_car_state;
-        // bool in_air_; // todo change to "status" and keep track of this
-        nav_msgs::Odometry curr_odom_ned;
-        sensor_msgs::NavSatFix gps_sensor_msg;
-
-        std::string odom_frame_id;
     };
 
     ros::ServiceServer reset_srvr_;
-    ros::Publisher origin_geo_point_pub_;          // home geo coord of drones
-    msr::airlib::GeoPoint origin_geo_point_;       // gps coord of unreal origin
-    fsds_ros_bridge::GPSYaw origin_geo_point_msg_; // todo duplicate
 
-    std::vector<FSCarROS> fscar_ros_vec_;
+    FSCarROS* fscar;
 
     std::vector<std::string> vehicle_names_;
     std::vector<VehicleSetting> vehicle_setting_vec_;
     AirSimSettingsParser airsim_settings_parser_;
     std::unordered_map<std::string, int> vehicle_name_idx_map_;
     static const std::unordered_map<int, std::string> image_type_int_to_string_map_;
-    std::map<std::string, std::string> vehicle_imu_map_;
     std::map<std::string, std::string> vehicle_lidar_map_;
     std::vector<geometry_msgs::TransformStamped> static_tf_msg_vec_;
     bool is_vulkan_; // rosparam obtained from launch file. If vulkan is being used, we BGR encoding instead of RGB
@@ -227,16 +218,18 @@ private:
 
     /// ROS Timers.
     ros::Timer airsim_img_response_timer_;
-    ros::Timer airsim_control_update_timer_;
+    ros::Timer odom_update_timer_;
+    ros::Timer gps_update_timer_;
+    ros::Timer imu_update_timer_;
     ros::Timer airsim_lidar_update_timer_;
     ros::Timer statistics_timer_;
+    ros::Timer statictf_timer_;
 
     typedef std::pair<std::vector<ImageRequest>, std::string> airsim_img_request_vehicle_name_pair;
     std::vector<airsim_img_request_vehicle_name_pair> airsim_img_request_vehicle_name_pair_vec_;
     std::vector<image_transport::Publisher> image_pub_vec_;
     std::vector<ros::Publisher> cam_info_pub_vec_;
     std::vector<ros::Publisher> lidar_pub_vec_;
-    std::vector<ros::Publisher> imu_pub_vec_;
 
     std::vector<sensor_msgs::CameraInfo> camera_info_msg_vec_;
 

--- a/ros/src/fsds_ros_bridge/launch/fsds_ros_bridge.launch
+++ b/ros/src/fsds_ros_bridge/launch/fsds_ros_bridge.launch
@@ -5,9 +5,12 @@
 
 	<node name="fsds_ros_bridge" pkg="fsds_ros_bridge" type="fsds_ros_bridge" output="screen">
 		<!-- ROS timer rates. Note that timer callback will be processed at maximum possible rate, upperbounded by the following ROS params -->
-		<param name="is_vulkan" type="bool" value="false" /> 
+		<param name="is_vulkan" type="bool" value="false" />
+		<param name="update_odom_every_n_sec" type="double" value="0.004" />
+		<param name="update_imu_every_n_sec" type="double" value="0.004" /> 
+		<param name="update_gps_every_n_sec" type="double" value="0.1" />
+		<param name="publish_static_tf_every_n_sec" type="double" value="1" />
 		<param name="update_airsim_img_response_every_n_sec" type="double" value="0.05" /> 
-		<param name="update_airsim_control_every_n_sec" type="double" value="0.001" />
 		<param name="update_lidar_every_n_sec" type="double" value="0.01" />
 		<param name="host_ip" type="string" value="$(arg host)" />
 		<param name="mission_name" type="string" value="$(arg mission)"/>


### PR DESCRIPTION
* Give imu and gps it's own timer, separate from car state updates as we want to set the frequency manually.
* Remove looped imu sensors since we will only support a single imu. just like we did with gps.
* Remove origin_geo_point publisher
* Remove the `static_tf_msg_vec_.clear();` line after the static  transforms has been sent. We want to keep sending those at a 1 second interval so moved them into their own timer.
* Refactored the odometry to be published at /odom and have it's own timer and setting.